### PR TITLE
Add test for favoriting monster user flow

### DIFF
--- a/cypress/integration/favoritePage_spec.js
+++ b/cypress/integration/favoritePage_spec.js
@@ -1,0 +1,21 @@
+beforeEach(() => {
+  cy.getMonster('awakened-shrub')
+  cy.visit('http://localhost:3000/monsters/0/awakened-shrub')
+})
+
+it('should be able to save and remove a monster to favorite list', () => {
+  cy.get('.monster-container > :nth-child(2) > :nth-child(1)')
+    .click()
+  cy.get('.nav-links > :nth-child(1) > .link')
+    .click()
+    .url('/favorites')
+  cy.get('.monster-list-item')
+    .contains('Awakened Shrub')
+    .click()
+    .url('/monsters/0/awakened-shrub')
+  cy.get('.monster-container > :nth-child(2) > :nth-child(2)')
+    .click()
+    .url('/favorites')
+  cy.get('.monster-list-item')
+    .should('not.exist')
+})


### PR DESCRIPTION
# Description
Added a test for favoriting and un favoriting monsters following present user flow. This test starts on the monster info component instead of main. Intercepts and stubs prior to tests running.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactor feature (non-breaking change that modifies existing work)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?
- [ ] open index.html / npm start
- [ ] console.log()
- [ ] dev tools
- [ ] npm test
- [x] Cypress
- [ ] other

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
